### PR TITLE
test(verror): fix assertion error

### DIFF
--- a/test/verror.test.js
+++ b/test/verror.test.js
@@ -36,7 +36,7 @@ describe('verror', function() {
     it("don't call extsprintf if pass single string to VError constructor", function() {
         const errString = 'my %s error';
         err = new VError(errString);
-        assert.equal(err.message, 'errString');
+        assert.equal(err.message, errString);
     });
 
     it('caused by another error, with no additional message */', function() {


### PR DESCRIPTION
## Issue

Travis CI is showing that the master branch is passing but in fact one of the tests is actually failing.

https://travis-ci.org/github/Netflix/nerror/jobs/617878815#L348

>   1 failing
>   1) verror
>        don't call extsprintf if pass single string to VError constructor:
>       AssertionError [ERR_ASSERTION]: 'my %s error' == 'errString'
>       + expected - actual
>       -my %s error
>       +errString
>       
>       at Context.<anonymous> (/home/travis/build/Netflix/nerror/test/verror.test.js:39:16)
>       at callFn (/home/travis/build/Netflix/nerror/node_modules/mocha/lib/runnable.js:372:21)
>       at Test.Runnable.run (/home/travis/build/Netflix/nerror/node_modules/mocha/lib/runnable.js:364:7)
>       at Runner.runTest (/home/travis/build/Netflix/nerror/node_modules/mocha/lib/runner.js:455:10)
>       at /home/travis/build/Netflix/nerror/node_modules/mocha/lib/runner.js:573:12
>       at next (/home/travis/build/Netflix/nerror/node_modules/mocha/lib/runner.js:369:14)
>       at /home/travis/build/Netflix/nerror/node_modules/mocha/lib/runner.js:379:7
>       at next (/home/travis/build/Netflix/nerror/node_modules/mocha/lib/runner.js:303:14)
>       at Immediate.<anonymous> (/home/travis/build/Netflix/nerror/node_modules/mocha/lib/runner.js:347:5)
>       at runCallback (timers.js:810:20)
>       at tryOnImmediate (timers.js:768:5)
>       at processImmediate [as _immediateCallback] (timers.js:745:5)
> Makefile:120: recipe for target 'test' failed
> make[1]: *** [test] Error 1
> make[1]: Leaving directory '/home/travis/build/Netflix/nerror'

## Change

Fixes the assertion error.

The assertion was passing `errString` as a `string` but it is actually suppose to be the variable reference.