### PR TITLE
refactor: replace lodash with lodash.iserror

### DIFF
--- a/lib/verror.js
+++ b/lib/verror.js
@@ -5,7 +5,7 @@
  */
 const util = require('util');
 
-const _ = require('lodash');
+const isError = require('lodash.iserror');
 const assert = require('assert-plus');
 const { sprintf } = require('extsprintf');
 
@@ -71,7 +71,7 @@ function parseConstructorArguments(args) {
     if (argv.length === 0) {
         options = {};
         sprintf_args = [];
-    } else if (_.isError(argv[0])) {
+    } else if (isError(argv[0])) {
         options = { cause: argv[0] };
         sprintf_args = argv.slice(1);
     } else if (typeof argv[0] === 'object') {
@@ -361,7 +361,7 @@ VError.prototype.cause = function ve_cause() {
 VError._assertError = function _assertError(err, msg) {
     assert.optionalString(msg, 'msg');
     const _msg = (msg || 'err must be an Error') + ` but got ${String(err)}`;
-    assert.ok(_.isError(err), _msg);
+    assert.ok(isError(err), _msg);
 };
 
 /**
@@ -419,7 +419,7 @@ VError.assignInfo = function assignInfo(err, obj) {
  */
 VError.cause = function cause(err) {
     VError._assertError(err);
-    return _.isError(err.jse_cause) ? err.jse_cause : null;
+    return isError(err.jse_cause) ? err.jse_cause : null;
 };
 
 /**
@@ -491,7 +491,7 @@ VError.findCauseByName = function findCauseByName(err, name) {
     assert.ok(name.length > 0, 'name cannot be empty');
 
     for (cause = err; cause !== null; cause = VError.cause(cause)) {
-        assert.ok(_.isError(cause));
+        assert.ok(isError(cause));
         if (cause.name === name) {
             return cause;
         }
@@ -565,7 +565,7 @@ VError.errorFromList = function errorFromList(errors) {
     }
 
     errors.forEach(function(e) {
-        assert.ok(_.isError(e), 'all errors must be an Error');
+        assert.ok(isError(e), 'all errors must be an Error');
     });
 
     if (errors.length === 1) {
@@ -805,7 +805,7 @@ WError.prototype.toString = function we_toString() {
  * @return {undefined|Error} Error cause
  */
 WError.prototype.cause = function we_cause(c) {
-    if (_.isError(c)) {
+    if (isError(c)) {
         this.jse_cause = c;
     }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "assert-plus": "^1.0.0",
     "extsprintf": "^1.4.0",
-    "lodash": "^4.17.15"
+    "lodash.iserror": "^3.1.1"
   },
   "scripts": {
     "test": "make prepush & tsd"

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -4,7 +4,7 @@
  * tests that cause works with errors from different contexts.
  */
 
-const _ = require('lodash');
+const isError = require('lodash.iserror');
 const assert = require('assert');
 const vm = require('vm');
 
@@ -14,13 +14,13 @@ describe('context', function() {
     it('should work with errors from different contexts', function(done) {
         const err = new Error();
         const verr = new VError(err);
-        assert.ok(_.isError(verr.cause()));
+        assert.ok(isError(verr.cause()));
 
         const context = vm.createContext({
             callback: function callback(err2) {
-                assert.ok(_.isError(err2));
+                assert.ok(isError(err2));
                 const verr2 = new VError(err);
-                assert.ok(_.isError(verr2.cause()));
+                assert.ok(isError(verr2.cause()));
                 done();
             }
         });


### PR DESCRIPTION
## Issue

Lodash is one of those packages that seems to have reoccuring reports for vulnerabilities. We are also loading an entire lodash library for only one method.

As it appears that `nerror` isnt updated frequently, we should try to not rely on a package that might lead to reoccuring vulnerabilities as we might need to constantly monitoring and updating if they decided to stop pushing updates to older releases.

## Solution

IMO, it would be safer to install the specific lodash export module for the `isError` method. Out of the entire lodash pacakge, we only use the `isError` method.

In this case, we can install the `lodash.iserror` package instead of `lodash`. This will potential reduce the possibility of seeing a vulnerability.

As an additional bonus, using `lodash.iserror` package will also greatly reduce the size of the install.

**`lodash`**:
```
npm notice package size:  319.0 kB
npm notice unpacked size: 1.4 MB
```

**`lodash.iserror`**:
```
npm notice package size:  2.2 kB
npm notice unpacked size: 4.4 kB
```