### PR TITLE
chore: lower Node engines floor back to >=22.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
 sudo: false
 language: node_js
 node_js:
+   - '22'
    - '24'
    - '26'
    - "lts/*"                # Active LTS release

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=24"
+    "node": ">=22.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Aligns with restify's own >=22.0.0 floor. Verified 78/78 tests pass on Node 22.