### PR TITLE
Replace cause method to property usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ program's name to the VError's `message`.  Or just call
 [node-cmdutil.fail(your_verror)](https://github.com/joyent/node-cmdutil), which
 does this for you.
 
-You can get the next-level Error using `err.cause()`:
+You can get the next-level Error using `err.cause` property:
 
 ```javascript
-console.error(err2.cause().message);
+console.error(err2.cause.message);
 ```
 
 prints:


### PR DESCRIPTION
## Summary
- The README showed `err.cause()` as an instance method, which does not exist and throws `TypeError`.
- `cause` on a `VError` instance is a property (`err.cause`). The static helper remains `VError.cause(err)`.
- Update the quick-start example to `err.cause.message` so it matches `lib/verror.js`.

```
const err = new VError(err1, 'stat "%s"', filename);

err.cause                    // the Error object (or undefined if none)
VError.cause(err)            // same Error, or null if none
err.cause()                 // TypeError
```